### PR TITLE
Remove dangling emphasis character from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This API provides job listings and job-related events for the [Workforce Develop
 
 ## Usage example
 
-_For more examples and usage, please refer to the [Wiki](https://github.com/sgfdevs/h4g-api-jobs/wiki).
+For more examples and usage, please refer to the [Wiki](https://github.com/sgfdevs/h4g-api-jobs/wiki).
 
 
 ## Contributing


### PR DESCRIPTION
Commit b59c847 ("Introduce Docker workflow with VS Code (#3)") updated
the README, and left a mistake in the document such that there was a
dangling emphasis markdown character. Remove this character.