### PR TITLE
Redo project setup documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ APP_URL=http://localhost
 LOG_CHANNEL=stack
 
 DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=33061
+DB_HOST=db
+DB_PORT=3306
 DB_DATABASE=jobsapi
 DB_USERNAME=root
 DB_PASSWORD=mypassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
     tty: true
     ports:
-      - "8080:80"
+      - "8000:80"
       - "4430:443"
     volumes:
       - ./:/var/www
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
     tty: true
     ports:
-      - "33061:3306"
+      - "3307:3306"
     environment:
       MYSQL_DATABASE: ${DB_DATABASE}
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,43 +2,77 @@
 
 The easiest way to get started with contributing to the project is to get started with the VS Code install.
 
-## Getting Started
+## Project Setup for Development
 
+### Perquisites
+
+1. Basic understanding of [Laravel 6.x](https://laravel.com/docs/6.x)
 1. Install [Docker](https://docs.docker.com/get-docker/) for your system
-1. Fork it (<https://github.com/Open-SGF/portal-to-work-api/fork>)
+1. Install [VS Code](https://code.visualstudio.com/docs/setup/setup-overview) for your system
+1. Fork this project (<https://github.com/Open-SGF/portal-to-work-api/fork>)
+1. Install project by cloning your forked repository to a location on your file system.
+
+### VS Code Setup
+
+1. Open up VS Code
+2. Install the "Remote Containers" (ms-vscode-remote remote-containers)
+3. Open the workspace for this project by navigating to `path/to/project/workspace.code-workspace`
+4. Open a [terminal Window](https://code.visualstudio.com/docs/editor/integrated-terminal) for the project
+5. Type in terminal: `cp .env.example .env` or if on Windows type: `copy .env.example .env` instead
+
+   This makes a local copy of _your_ environment settings that you're free to modify for this project.
+
+6. Edit the `.env` file, specifically these option(s):
+
+	**DB_PASSWORD** - This will be your database password, so please provide one.
+
+7. Open the [VS Code command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) and type the command `Remote-Containers: Rebuild and Reopen in Container` and hit enter.
+
+   This will re-launch VS Code to work off a container environment. This environment contains all the tools you'll need to develop for this project. This step may take a while.
+
+8. When container is open, open up a [terminal Window](https://code.visualstudio.com/docs/editor/integrated-terminal)
+
+9. Run `composer install`
+
+   This will install all the PHP dependencies for the project. This may take a while.
+
+10. Run `php artisan key:generate`
+
+    This creates a project key used for authentication security.
+
+11. Run `php artisan migrate`
+
+    This creates the tables, views, etc... for the database.
+
+12. Run `php artisan db:seed`
+
+    This fills the database with fake data.
+
+Your app is installed and setup at the location defined in `APP_URL` at port 8080 or [http://localhost:8000](http://localhost:8000) depending on your `.env` file settings.
+
+### Closing down the containers
+
+Make a habit of closing down the project after finishing some work. This will save some computer resources.
+
+1. Open the [VS Code command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette)
+
+2. Type and run: `Remote: Close remote Connection`
+
+   This will close down the Docker connections.
+
+To resume work after shutting down
+
+1. Open VS Code
+
+2. Navigate to the project
+
+3. Open the [VS Code command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette)
+
+4. Type and run: `Remote-Containers: Open Workspace in Container`
+
+## Create a PR
+
 1. Create your feature branch (`git checkout -b feature/fooBar`)
 1. Commit your changes (`git commit -am 'Add some fooBar'`)
 1. Push to the branch (`git push origin head`)
 1. Create a new Pull Request
-
-## VS Code Setup
-
-1. Install & Open up VS Code
-2. Install extension: `ext install ms-vscode-remote.remote-containers`
-3. Open this workspace (by navigating to this project folder in system)
-
-Project Setup:
-
-4. Run `cp .env.example .env`
-5. Edit the .env file, specfically these option(s):
-
-	DB_PASSWORD
-
-6. Open new terminal window, or new terminal in VS Code
-
-If not using VS Code's terminal
-
-7. Run `docker-compose build`
-8. Run `docker-comose up`
-9. Open a new terminal window
-10. Run `docker exec -ti app bash`
-11. Go to step 12
-
-If using VS Code's Terminal & Connected to remote container
-
-12. Run `php artisan key:generate`
-13. Run `php artisan migrate`
-14. Run `php artisan db:seed`
-15. Run `exit`
-
-Your app is installed and setup at the location defined in `APP_URL` at port 8080 or [http://localhost:8080](http://localhost:8080) when using mostly defaults.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,17 +7,17 @@ The easiest way to get started with contributing to the project is to get starte
 ### Perquisites
 
 1. Basic understanding of [Laravel 6.x](https://laravel.com/docs/6.x)
-1. Install [Docker](https://docs.docker.com/get-docker/) for your system
-1. Install [VS Code](https://code.visualstudio.com/docs/setup/setup-overview) for your system
-1. Fork this project (<https://github.com/Open-SGF/portal-to-work-api/fork>)
-1. Install project by cloning your forked repository to a location on your file system.
+2. Install [Docker](https://docs.docker.com/get-docker/) for your system
+3. Install [VS Code](https://code.visualstudio.com/docs/setup/setup-overview) for your system
+4. Fork this project (<https://github.com/Open-SGF/portal-to-work-api/fork>)
+5. Install project by cloning your forked repository to a location on your file system.
 
 ### VS Code Setup
 
 1. Open up VS Code
-2. Install the "Remote Containers" (ms-vscode-remote remote-containers)
+2. [Install](https://code.visualstudio.com/docs/editor/extension-marketplace) the "Remote Containers" (ms-vscode-remote remote-containers) VS Code extension
 3. Open the workspace for this project by navigating to `path/to/project/workspace.code-workspace`
-4. Open a [terminal Window](https://code.visualstudio.com/docs/editor/integrated-terminal) for the project
+4. Open a [terminal window](https://code.visualstudio.com/docs/editor/integrated-terminal) for the project
 5. Type in terminal: `cp .env.example .env` or if on Windows type: `copy .env.example .env` instead
 
    This makes a local copy of _your_ environment settings that you're free to modify for this project.
@@ -30,25 +30,25 @@ The easiest way to get started with contributing to the project is to get starte
 
    This will re-launch VS Code to work off a container environment. This environment contains all the tools you'll need to develop for this project. This step may take a while.
 
-8. When container is open, open up a [terminal Window](https://code.visualstudio.com/docs/editor/integrated-terminal)
+8. When container is open, open up a [terminal window](https://code.visualstudio.com/docs/editor/integrated-terminal) in the container
 
-9. Run `composer install`
+9. Type & run `composer install`
 
    This will install all the PHP dependencies for the project. This may take a while.
 
-10. Run `php artisan key:generate`
+10. Type & run `php artisan key:generate`
 
-    This creates a project key used for authentication security.
+    This creates a salt key used for authentication security. This is not to be confused with `?app_token` for htting the API.
 
-11. Run `php artisan migrate`
+11. Type & run `php artisan migrate`
 
     This creates the tables, views, etc... for the database.
 
-12. Run `php artisan db:seed`
+12. Type & run `php artisan db:seed`
 
     This fills the database with fake data.
 
-Your app is installed and setup at the location defined in `APP_URL` at port 8080 or [http://localhost:8000](http://localhost:8000) depending on your `.env` file settings.
+Your app is installed and setup at the location defined in `APP_URL` at port 8000 or [http://localhost:8000](http://localhost:8000) depending on your `.env` file settings.
 
 ### Closing down the containers
 
@@ -56,7 +56,7 @@ Make a habit of closing down the project after finishing some work. This will sa
 
 1. Open the [VS Code command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette)
 
-2. Type and run: `Remote: Close remote Connection`
+2. Type & run `Remote: Close remote Connection`
 
    This will close down the Docker connections.
 
@@ -68,11 +68,11 @@ To resume work after shutting down
 
 3. Open the [VS Code command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette)
 
-4. Type and run: `Remote-Containers: Open Workspace in Container`
+4. Type & run `Remote-Containers: Open Workspace in Container`
 
 ## Create a PR
 
 1. Create your feature branch (`git checkout -b feature/fooBar`)
-1. Commit your changes (`git commit -am 'Add some fooBar'`)
-1. Push to the branch (`git push origin head`)
-1. Create a new Pull Request
+2. Commit your changes (`git commit -am 'Add some fooBar'`)
+3. Push to the branch (`git push origin head`)
+4. Create a new Pull Request

--- a/mysql/init.sql
+++ b/mysql/init.sql
@@ -1,1 +1,0 @@
--- CREATE DATABASE IF NOT EXISTS jobsapi;


### PR DESCRIPTION
Commit b59c847 ("Introduce Docker workflow with VS Code (#3)") introduced a process to setup the project, but was incomplete and didn't clarify the process. This fixes that by sticking to VS Code only, and to fix up the defaults.